### PR TITLE
Fix wsock_handshake:handle_response/2 spec

### DIFF
--- a/src/wsock_handshake.erl
+++ b/src/wsock_handshake.erl
@@ -35,7 +35,7 @@ handle_open(Message) ->
       {error, ?INVALID_CLIENT_OPEN}
   end.
 
--spec handle_response(Response::#http_message{}, Handshake::#handshake{}) -> {ok, ?INVALID_SERVER_RESPONSE} | {ok, #handshake{}}.
+-spec handle_response(Response::#http_message{}, Handshake::#handshake{}) -> {ok, #handshake{}} | {error, ?INVALID_SERVER_RESPONSE}.
 handle_response(Response, Handshake) ->
   case validate_handshake_response(Response, Handshake) of
     true ->


### PR DESCRIPTION
This error propagated to wsecli and caused dialyzer to error there.
I've also pushed tag 1.1.5 accompanying this change to my repo so Rebar deps can be sorted out nicely.
I'd great if you could ensure that tag is pushed to your repo too.
