### PR TITLE
Add support for cookie based authentication in the initial handshake

### DIFF
--- a/src/wsock_handshake.erl
+++ b/src/wsock_handshake.erl
@@ -17,7 +17,7 @@
 -module(wsock_handshake).
 -include("wsock.hrl").
 
--export([open/3, handle_response/2]).
+-export([open/3, open/4, handle_response/2]).
 -export([handle_open/1, response/1]).
 
 -define(VERSION, 13).
@@ -82,6 +82,25 @@ open(Resource, Host, Port) ->
   Message = wsock_http:build(request, RequestLine, Headers),
   {ok, #handshake{ version = ?VERSION, type = open, message = Message}}.
 
+
+-spec open(Resource ::string(), Host ::string(), Port::integer(), Cookie::string()) -> {ok, #handshake{}}.
+open(Resource, Host, Port, Cookie) when is_integer(Port) ->
+  RequestLine = [
+    {method, "GET"},
+    {version, "1.1"},
+    {resource, Resource}
+  ],
+
+  Headers =[ 
+    {"Host", lists:flatten([Host, ":", integer_to_list(Port)])},
+    {"Upgrade", "websocket"},
+    {"Connection", "upgrade"},
+    {"Sec-Websocket-Key", wsock_key:generate()},
+    {"Sec-Websocket-Version", integer_to_list(?VERSION)},
+    {"Cookie", Cookie}
+  ],
+  Message = wsock_http:build(request, RequestLine, Headers),
+  {ok, #handshake{ version = ?VERSION, type = open, message = Message}}.  
 
 %=======================
 % INTERNAL FUNCTIONS

--- a/src/wsock_message.erl
+++ b/src/wsock_message.erl
@@ -27,7 +27,7 @@
 %%========================================
 %% Types
 %%========================================
--type message_type()   :: begin_message | continue_message.
+-type message_type()   :: begin_message | continue_message | continue.
 
 % @type decode_options() = masked.
 % @type encode_options() = mask.
@@ -356,6 +356,8 @@ process_frame(control_fragment, _ ,_, _) ->
 process_frame(open_close, _, Frame, Message) ->
   frame_to_complete_message(Frame, Message);
 process_frame(open_continue, _, Frame, Message) ->
+  frame_for_fragmented_message(Frame, Message);
+process_frame(continue, begin_message, Frame, Message) ->
   frame_for_fragmented_message(Frame, Message);
 process_frame(continue, continue_message, Frame, Message) ->
   frame_for_fragmented_message(Frame, Message);


### PR DESCRIPTION
Add a new function open/4, which is open/3 with a forth parameter, which becomes an additional header - Cookie.
Assume this authentication cookie was obtained in a previous step using a http auth mechanism. 

My usage scenario is using [ibrowse](https://github.com/cmullaparthi/ibrowse) to do the http authentication step in the following manner:

``` erlang
Answer = ibrowse:send_req(Url, Headers, post, Body, Options),
case Answer of
        {ok, Status, ResponseHeaders, _ResponseBody} ->
            Cookies = get_cookies(ResponseHeaders),
            AuthCookie = find_cookie(AuthCookiePattern, Cookies),
            {ok, AuthCookie}
       %...
end
HandshakeRequest = wsock_handshake:open(Resource, Url, Port, AuthCookie)
```
